### PR TITLE
Update broken external link

### DIFF
--- a/gnu/gcc/gcc/bb-reorder.c
+++ b/gnu/gcc/gcc/bb-reorder.c
@@ -61,7 +61,7 @@
 
    "Software Trace Cache"
    A. Ramirez, J. Larriba-Pey, C. Navarro, J. Torrellas and M. Valero; 1999
-   https://dl.acm.org/citation.cfm?doid=305138.305178
+   https://doi.org/10.1145/305138.305178
 
 */
 

--- a/gnu/gcc/gcc/bb-reorder.c
+++ b/gnu/gcc/gcc/bb-reorder.c
@@ -61,7 +61,7 @@
 
    "Software Trace Cache"
    A. Ramirez, J. Larriba-Pey, C. Navarro, J. Torrellas and M. Valero; 1999
-   http://citeseer.nj.nec.com/15361.html
+   https://dl.acm.org/citation.cfm?doid=305138.305178
 
 */
 


### PR DESCRIPTION
Updated a broken link reference that was moved from
   http://citeseer.nj.nec.com/15361.html
to 
  https://dl.acm.org/citation.cfm?doid=305138.305178